### PR TITLE
Change the MAC address lookup to case insensitive

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ if (argv.p === true) {
     argv.p = readlineSync.question('MQTT Password: ', {hideEchoBack: true, mask: ''});
 }
 
-const idsToConnectTo = argv._.filter(name => !name.startsWith('_')).map(name => name.replace(/:/g, ''));
+const idsToConnectTo = argv._.filter(name => !name.startsWith('_')).map(name => name.replace(/:/g, '').toLowerCase());
 
 if(idsToConnectTo.length === 0)
 {
@@ -102,7 +102,7 @@ if (expressPort) {
 noble.on('warning', (message) => {debugLog(message)});
 
 noble.on('discover', peripheral => {
-    let id = peripheral.address !== undefined ? peripheral.address.replace(/:/g, '') : undefined;
+    let id = peripheral.address !== undefined ? peripheral.address.replace(/:/g, '').toLowerCase() : undefined;
 
     if (idsToConnectTo.indexOf(id) === -1) {
         debugLog('Found %s but will not connect as it was not specified in the list of devices %o', id, idsToConnectTo);


### PR DESCRIPTION
Didn't work out of the box for me as discovered addresses are using lower case letters:
```
$ sudo node_modules/.bin/am43ctrl "02:0C:B3:xx:xx:xx" --express-port 3000 -d
  am43* scanning for 1 device(s) [ '020CB3xxxxxx' ] +0ms
  am43 listening on port 3000 +0ms
  am43 Found 020cb3xxxxxx but will not connect as it was not specified in the list of devices [ '020CB3xxxxxx' ] +61ms
```
With the fix:
```
node_modules/.bin/am43ctrl 02:0C:B3:xx:xx:xx --express-port 3000 -d
  am43* scanning for 1 device(s) [ '020cb3xxxxxx' ] +0ms
  am43 listening on port 3000 +0ms
  am43* discovered 020cb3xxxxxx +953ms
  am43* all expected devices connected, stopping scan +1ms
```