### PR TITLE
Replace MQTT value_template with position_template

### DIFF
--- a/src/MQTTConnector.js
+++ b/src/MQTTConnector.js
@@ -74,7 +74,7 @@ class MQTTConnector {
             payload_not_available: 'Offline',
             unique_id: `am43_${device.id}_battery_sensor`,
             device: deviceInfo,
-            position_template: '{{value_json[\'battery\']}}',
+            value_template: '{{value_json[\'battery\']}}',
             device_class: 'battery',
             unit_of_measurement: '%'
         };
@@ -87,7 +87,7 @@ class MQTTConnector {
             payload_not_available: 'Offline',
             unique_id: `am43_${device.id}_light_sensor`,
             device: deviceInfo,
-            position_template: '{{value_json[\'light\']}}',
+            value_template: '{{value_json[\'light\']}}',
             unit_of_measurement: '%'
         };
 

--- a/src/MQTTConnector.js
+++ b/src/MQTTConnector.js
@@ -61,7 +61,7 @@ class MQTTConnector {
             payload_open: 'OPEN',
             payload_close: 'CLOSE',
             payload_stop: 'STOP',
-            value_template: '{{value_json[\'position\']}}',
+            position_template: '{{value_json[\'position\']}}',
             unique_id: `am43_${device.id}_cover`,
             device: deviceInfo
         };
@@ -74,7 +74,7 @@ class MQTTConnector {
             payload_not_available: 'Offline',
             unique_id: `am43_${device.id}_battery_sensor`,
             device: deviceInfo,
-            value_template: '{{value_json[\'battery\']}}',
+            position_template: '{{value_json[\'battery\']}}',
             device_class: 'battery',
             unit_of_measurement: '%'
         };
@@ -87,7 +87,7 @@ class MQTTConnector {
             payload_not_available: 'Offline',
             unique_id: `am43_${device.id}_light_sensor`,
             device: deviceInfo,
-            value_template: '{{value_json[\'light\']}}',
+            position_template: '{{value_json[\'light\']}}',
             unit_of_measurement: '%'
         };
 


### PR DESCRIPTION
Avoid deprecation warning from Home Assistant.

I am not sure whether we can keep `value_template` for backwards compatibility. This depends on how HA will handle this case with the next version. I'd remove `value_template` completly (like in the PR) to avoid problems in the future. HA has implemented `position_template` long enough, I guess.

The code is untested. I have no dev environment and am not firm enough with Node.js to check it. @binsentsu could you take a look into this? I'd really appreciate your help.