### PR TITLE
Fixes for HA 2016.6.6

### DIFF
--- a/src/MQTTConnector.js
+++ b/src/MQTTConnector.js
@@ -50,6 +50,7 @@ class MQTTConnector {
 
         let coverConfig = {
             name: device.id,
+            state_topic: `${deviceTopic}/state`,
             command_topic: `${deviceTopic}/set`,
             position_topic: `${deviceTopic}/state`,
             set_position_topic: `${deviceTopic}/setposition`,


### PR DESCRIPTION
This PR fixes binsentsu/am43-ctrl#34.

I am currently recieving the following error.
@binsentsu any ideas on this? I tried several things, but can not get rid of the warning. Everything else is working as expected.

```
2021-06-24 17:01:15 WARNING (MainThread) [homeassistant.components.mqtt.cover] Payload is not supported (e.g. open, closed, opening, closing, stopped): {"id":"0245f32c8f21","lastconnect":"2021-06-24T15:01:14.418Z","lastsuccess":"2021-06-24T15:01:15.728Z","lastaction":null,"state":"OPEN","battery":42,"light":7,"position":0}
```

I read things here, but couldn't derive a solution from that.
- https://community.home-assistant.io/t/payload-is-not-supported-e-g-open-closed-opening-closing-stopped-stop/306122/11
- https://www.home-assistant.io/integrations/cover.mqtt/#state_closed